### PR TITLE
Added flags 'reprocess-erase' and 'overwrite'

### DIFF
--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -26,7 +26,8 @@ class Pagemaster < Jekyll::Command
         meta = {
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
-          'source'  => config['collections'][name].fetch('source')
+          'source'  => config['collections'][name].fetch('source'),
+          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false)
         }
         data = ingest(meta)
         generate_pages(name, meta, data, perma)
@@ -59,13 +60,18 @@ class Pagemaster < Jekyll::Command
       completed = 0
       skipped = 0
       dir = '_' + name
+
+      if meta['reprocess_erase']
+        FileUtils.rm_rf(dir)
+      end
+
       mkdir_p(dir)
       data.each do |item|
         pagename = slug(item.fetch(meta['id_key']))
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath)
+        if File.exist?(pagepath) and !meta['overwrite']
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -27,7 +27,8 @@ class Pagemaster < Jekyll::Command
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
           'source'  => config['collections'][name].fetch('source'),
-          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false)
+          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false),
+          'overwrite' => config['collections'][name].fetch('overwrite', false)
         }
         data = ingest(meta)
         generate_pages(name, meta, data, perma)
@@ -71,7 +72,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath)
+        if File.exist?(pagepath) and !meta['overwrite']
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -71,7 +71,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath) and !meta['overwrite']
+        if File.exist?(pagepath)
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -11,7 +11,8 @@ class Pagemaster < Jekyll::Command
       prog.command(:pagemaster) do |c|
         c.syntax 'pagemaster [options] [args]'
         c.description 'Generate md pages from collection data.'
-        c.option 'no-perma', '--no-permalink', 'Skips adding hard-coded permalink'
+        c.option 'no-perma', '--no-permalink', 'Skips adding hard-coded permalink.'
+        c.option 'force', '--force', 'Erases pre-existing collection before generating.'
         c.action { |args, options| execute(args, options) }
       end
     end
@@ -21,17 +22,16 @@ class Pagemaster < Jekyll::Command
       abort 'Cannot find collections in config' unless config.key?('collections')
       perma = false
       perma = config['permalink'] == 'pretty' ? '/' : '.html' unless options.key? 'no-perma'
+      force = options['force'] || false
       args.each do |name|
         abort "Cannot find #{name} in collection config" unless config['collections'].key? name
         meta = {
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
-          'source'  => config['collections'][name].fetch('source'),
-          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false),
-          'overwrite' => config['collections'][name].fetch('overwrite', false)
+          'source'  => config['collections'][name].fetch('source')
         }
         data = ingest(meta)
-        generate_pages(name, meta, data, perma)
+        generate_pages(name, meta, data, perma, force)
       end
     end
 
@@ -57,12 +57,12 @@ class Pagemaster < Jekyll::Command
       abort "Your collection duplicate ids: \n#{duplicates}" unless duplicates.empty?
     end
 
-    def generate_pages(name, meta, data, perma)
+    def generate_pages(name, meta, data, perma, force)
       completed = 0
       skipped = 0
       dir = '_' + name
 
-      if meta['reprocess_erase']
+      if force
         FileUtils.rm_rf(dir)
       end
 
@@ -72,7 +72,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath) and !meta['overwrite']
+        if File.exist?(pagepath) and !force
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else


### PR DESCRIPTION
After using the pagemaster gem, there are two use cases that seem very important to have. The first one is to erase the collection that pagemaster had generated in the case that new files are generated in the collection. The second is to overwrite pre-existing files that are processed instead of disabling that by default.

I am proposing two new optional parameters:
1. On reprocess, erase the collection (**reprocess_erase**).
2. On reprocess, overwrite existing files (**overwrite**).