### PR TITLE
Force option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  - apt-get install tree
 script:
   - bundle exec rspec
   - bundle exec rubocop
 after_script:
-  - tree build
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - apt-get install tree
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -62,7 +62,10 @@ class Pagemaster < Jekyll::Command
       dir       = "_#{name}"
       perma     = opts.fetch(:no_perma, meta[:ext])
 
-      FileUtils.rm_rf(dir) if opts.fetch(:force, false)
+      if opts.fetch(:force, false)
+        FileUtils.rm_rf(dir)
+        puts "Overwriting #{dir} directory with --force."
+      end
 
       mkdir_p(dir)
       data.each do |item|

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -26,7 +26,8 @@ class Pagemaster < Jekyll::Command
         meta = {
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
-          'source'  => config['collections'][name].fetch('source')
+          'source'  => config['collections'][name].fetch('source'),
+          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false)
         }
         data = ingest(meta)
         generate_pages(name, meta, data, perma)
@@ -59,13 +60,18 @@ class Pagemaster < Jekyll::Command
       completed = 0
       skipped = 0
       dir = '_' + name
+
+      if meta['reprocess_erase']
+        FileUtils.rm_rf(dir)
+      end
+
       mkdir_p(dir)
       data.each do |item|
         pagename = slug(item.fetch(meta['id_key']))
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath)
+        if File.exist?(pagepath) and !meta['overwrite']
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -27,7 +27,8 @@ class Pagemaster < Jekyll::Command
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
           'source'  => config['collections'][name].fetch('source'),
-          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false)
+          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false),
+          'overwrite' => config['collections'][name].fetch('overwrite', false)
         }
         data = ingest(meta)
         generate_pages(name, meta, data, perma)
@@ -71,7 +72,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath)
+        if File.exist?(pagepath) and !meta['overwrite']
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -71,7 +71,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath) and !meta['overwrite']
+        if File.exist?(pagepath)
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -11,7 +11,8 @@ class Pagemaster < Jekyll::Command
       prog.command(:pagemaster) do |c|
         c.syntax 'pagemaster [options] [args]'
         c.description 'Generate md pages from collection data.'
-        c.option 'no-perma', '--no-permalink', 'Skips adding hard-coded permalink'
+        c.option 'no-perma', '--no-permalink', 'Skips adding hard-coded permalink.'
+        c.option 'force', '--force', 'Erases pre-existing collection before generating.'
         c.action { |args, options| execute(args, options) }
       end
     end
@@ -21,17 +22,16 @@ class Pagemaster < Jekyll::Command
       abort 'Cannot find collections in config' unless config.key?('collections')
       perma = false
       perma = config['permalink'] == 'pretty' ? '/' : '.html' unless options.key? 'no-perma'
+      force = options['force'] || false
       args.each do |name|
         abort "Cannot find #{name} in collection config" unless config['collections'].key? name
         meta = {
           'id_key'  => config['collections'][name].fetch('id_key'),
           'layout'  => config['collections'][name].fetch('layout'),
-          'source'  => config['collections'][name].fetch('source'),
-          'reprocess_erase' => config['collections'][name].fetch('reprocess_erase', false),
-          'overwrite' => config['collections'][name].fetch('overwrite', false)
+          'source'  => config['collections'][name].fetch('source')
         }
         data = ingest(meta)
-        generate_pages(name, meta, data, perma)
+        generate_pages(name, meta, data, perma, force)
       end
     end
 
@@ -57,12 +57,12 @@ class Pagemaster < Jekyll::Command
       abort "Your collection duplicate ids: \n#{duplicates}" unless duplicates.empty?
     end
 
-    def generate_pages(name, meta, data, perma)
+    def generate_pages(name, meta, data, perma, force)
       completed = 0
       skipped = 0
       dir = '_' + name
 
-      if meta['reprocess_erase']
+      if force
         FileUtils.rm_rf(dir)
       end
 
@@ -72,7 +72,7 @@ class Pagemaster < Jekyll::Command
         pagepath = dir + '/' + pagename + '.md'
         item['permalink'] = '/' + name + '/' + pagename + perma if perma
         item['layout'] = meta['layout']
-        if File.exist?(pagepath) and !meta['overwrite']
+        if File.exist?(pagepath) and !force
           puts "#{pagename}.md already exits. Skipping."
           skipped += 1
         else

--- a/pagemaster.gemspec
+++ b/pagemaster.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'pagemaster'
-  s.version       = '2.1.0'
+  s.version       = '2.0.2'
   s.date          = '2018-03-27'
   s.summary       = 'jekyll pagemaster plugin'
   s.description   = 'jekyll plugin for generating md pages from csv/json/yml'

--- a/pagemaster.gemspec
+++ b/pagemaster.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name          = 'pagemaster'
-  s.version       = '2.0.2'
+  s.version       = '2.1.0'
   s.date          = '2018-03-27'
   s.summary       = 'jekyll pagemaster plugin'
   s.description   = 'jekyll plugin for generating md pages from csv/json/yml'
-  s.authors       = ['Marii Nyröp']
+  s.authors       = ['Marii Nyrop']
   s.files         = ['lib/pagemaster.rb']
   s.require_path  = 'lib'
   s.homepage      = 'https://github.com/mnyrop/pagemaster'

--- a/spec/fake/helpers.rb
+++ b/spec/fake/helpers.rb
@@ -29,3 +29,25 @@ def add_collections_to_config(args, collection_data)
   output = YAML.dump config
   File.write('_config.yml', output)
 end
+
+def quiet_stdout
+  if QUIET
+    begin
+      orig_stderr = $stderr.clone
+      orig_stdout = $stdout.clone
+      $stderr.reopen File.new('/dev/null', 'w')
+      $stdout.reopen File.new('/dev/null', 'w')
+      retval = yield
+    rescue StandardError => e
+      $stdout.reopen orig_stdout
+      $stderr.reopen orig_stderr
+      raise e
+    ensure
+      $stdout.reopen orig_stdout
+      $stderr.reopen orig_stderr
+    end
+    retval
+  else
+    yield
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,27 +8,28 @@ require 'fake/data'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'pagemaster'
 
-include FileUtils
+QUIET = !ENV['DEBUG']
 
 describe 'pagemaster' do
   Fake.site
   collection_data = Fake.data
   args = collection_data.map { |c| c[0] }
   add_collections_to_config(args, collection_data)
-  dirs = args.map { |a| '_' + a }
+
+  let(:dirs) { args.map { |a| "_#{a}" } }
 
   context 'with --no-permalink' do
     it 'throws no errors' do
-      Pagemaster.execute(args, no_perma: true)
+      expect { quiet_stdout { Pagemaster.execute(args, no_perma: true) } }.not_to raise_error
     end
     it 'makes the correct dirs' do
       dirs.each { |dir| expect(exist(dir)) }
     end
     it 'generates md pages' do
-      dirs.each { |dir| expect(Dir.glob(dir + '/*.md')) }
+      dirs.each { |dir| expect(Dir.glob("#{dir}/*.md")) }
     end
     it 'skips writing permalinks' do
-      Dir.glob(dirs.first + '/*.md').each do |p|
+      Dir.glob("#{dirs.first}/*.md").each do |p|
         page = YAML.load_file(p)
         expect(!page.key?('permalink'))
       end
@@ -37,26 +38,26 @@ describe 'pagemaster' do
 
   context 'with --force' do
     it 'throws no errors' do
-      Pagemaster.execute(args, force: true)
+      expect { quiet_stdout { Pagemaster.execute(args, force: true) } }.not_to raise_error
     end
     it 'deletes the dir' do
-      # fill in
+      expect { Pagemaster.execute(args, force: true) }.to output(/.*Overwriting.*/).to_stdout
+      expect { Pagemaster.execute(args, force: true) }.not_to output(/.*Skipping.*/).to_stdout
     end
     it 'regenerates md pages' do
-      # fill in
+      dirs.each { |dir| expect(Dir.glob("#{dir}/*.md")) }
     end
   end
 
   context 'with default options' do
     it 'throws no errors' do
-      rm_rf(dirs)
-      Pagemaster.execute(args)
+      expect { quiet_stdout { Pagemaster.execute(args) } }.not_to raise_error
     end
     it 'skips existing pages' do
-      # fill in
+      expect { Pagemaster.execute([args.first]) }.to output(/.*Skipping.*/).to_stdout
     end
     it 'writes permalinks' do
-      Dir.glob(dirs.first + '/*.md').each do |p|
+      Dir.glob("#{dirs.first}/*.md").each do |p|
         page = YAML.load_file(p)
         expect(page.key?('permalink'))
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,9 +18,8 @@ describe 'pagemaster' do
   dirs = args.map { |a| '_' + a }
 
   context 'with --no-permalink' do
-    options = { 'no-perma' => true }
     it 'throws no errors' do
-      Pagemaster.execute(args, options)
+      Pagemaster.execute(args, no_perma: true)
     end
     it 'makes the correct dirs' do
       dirs.each { |dir| expect(exist(dir)) }
@@ -36,11 +35,25 @@ describe 'pagemaster' do
     end
   end
 
+  context 'with --force' do
+    it 'throws no errors' do
+      Pagemaster.execute(args, force: true)
+    end
+    it 'deletes the dir' do
+      # fill in
+    end
+    it 'regenerates md pages' do
+      # fill in
+    end
+  end
+
   context 'with default options' do
-    options = {}
     it 'throws no errors' do
       rm_rf(dirs)
-      Pagemaster.execute(args, options)
+      Pagemaster.execute(args)
+    end
+    it 'skips existing pages' do
+      # fill in
     end
     it 'writes permalinks' do
       Dir.glob(dirs.first + '/*.md').each do |p|


### PR DESCRIPTION
`$ bundle exec jekyll pagemaster <collection> --force` removes the collection dir and regenerates pages

Supersedes PR [#8](https://github.com/mnyrop/pagemaster/pull/8)