### PR TITLE
Respect Jekyll 'source' global config option

### DIFF
--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -35,7 +35,7 @@ class Pagemaster < Jekyll::Command
     end
 
     def ingest(meta)
-      src = File.join(meta[:subdir], "_data", meta[:source])
+      src = File.join((meta[:subdir].to_s.strip.empty? ? meta[:subdir] : "." ), "_data", meta[:source])
       puts "Processing #{src}...."
       data = case File.extname(src)
              when '.csv'
@@ -60,7 +60,7 @@ class Pagemaster < Jekyll::Command
     end
 
     def generate_pages(name, meta, data, opts)
-      dir       = File.join(meta[:subdir], "_#{name}")
+      dir       = File.join((meta[:subdir].to_s.strip.empty? ? meta[:subdir] : "." ), "_#{name}")
       perma     = opts.fetch(:no_perma, meta[:ext])
 
       if opts.fetch(:force, false)

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -35,7 +35,7 @@ class Pagemaster < Jekyll::Command
     end
 
     def ingest(meta)
-      src = "_data/#{meta[:source]}"
+      src = File.join(meta[:subdir], "_data", meta[:source])
       puts "Processing #{src}...."
       data = case File.extname(src)
              when '.csv'
@@ -60,7 +60,7 @@ class Pagemaster < Jekyll::Command
     end
 
     def generate_pages(name, meta, data, opts)
-      dir       = "_#{name}"
+      dir       = File.join(meta[:subdir], "_#{name}")
       perma     = opts.fetch(:no_perma, meta[:ext])
 
       if opts.fetch(:force, false)

--- a/lib/pagemaster.rb
+++ b/lib/pagemaster.rb
@@ -26,6 +26,7 @@ class Pagemaster < Jekyll::Command
           id_key: config['collections'][name].fetch('id_key'),
           layout: config['collections'][name].fetch('layout'),
           source: config['collections'][name].fetch('source'),
+          subdir: config.fetch('source', ''),
           ext:    config.fetch('permalink', '') == 'pretty' ? '/' : '.html'
         }
         data = ingest(meta)


### PR DESCRIPTION
Prepends the jekyll source directory so that pagemaster just works even if the project is in a subdir

https://jekyllrb.com/docs/configuration/options/