### PR TITLE
Change the Way the Resulting Markdown Header is Created

### DIFF
--- a/lib/pagemaster/collection.rb
+++ b/lib/pagemaster/collection.rb
@@ -92,6 +92,7 @@ module Pagemaster
       @data = ingest_source
       validate_data
 
+      processed_paths = []
       @data.map do |data_entry|
         puts("Processing #{data_entry}")
         path = "#{@dir}/#{slug(data_entry[@id_key])}.md"
@@ -110,7 +111,9 @@ module Pagemaster
           File.open(path, 'w') { |file| file.write("#{new_entry.to_yaml}---") }
         end
         puts(Rainbow("Written #{path}").cyan)
+        processed_paths.append(path)
       end
+      return processed_paths
     end
 
     #

--- a/lib/pagemaster/collection.rb
+++ b/lib/pagemaster/collection.rb
@@ -10,11 +10,12 @@ module Pagemaster
     #
     #
     def initialize(name, config)
-      @name = name
-      @config = config
-      @source = fetch('source')
-      @id_key = fetch('id_key')
-      @title_key = fetch('title_key')
+      @name               = name
+      @config             = config
+      @source             = fetch('source')
+      @id_key             = fetch('id_key')
+      @title_key          = fetch('title_key')
+      @frontmatter_extra  = fetch('frontmatter_extra') if config.key?('frontmatter_extra')
     end
 
     # Go through the configuration and return the value for the given key
@@ -88,6 +89,7 @@ module Pagemaster
       new_entry['layout'] = @config['layout'] if @config.key?('layout')
       new_entry['title'] = title
       new_entry['data'] = data_entry
+      new_entry = new_entry.merge(@frontmatter_extra) if @frontmatter_extra
 
       if File.exist?(path)
         puts(Rainbow("#{path} already exits. Skipping.").cyan)

--- a/lib/pagemaster/collection.rb
+++ b/lib/pagemaster/collection.rb
@@ -4,38 +4,47 @@ module Pagemaster
   #
   #
   class Collection
+    # Make the following attribute symbols readable
     attr_reader :source, :id_key, :layout, :data, :dir
 
     #
     #
     def initialize(name, config)
-      @name   = name
-      @config = config
-      @source = fetch 'source'
-      @id_key = fetch 'id_key'
+      @name       = name
+      @config     = config
+      @source     = fetch('source')
+      @id_key     = fetch('id_key')
+      @title_key  = fetch('title_key')
     end
 
-    #
-    #
+    # Go through the configuration and return the value for the given key
+    # If the key does not exist, raise an error
+    # @param key that is supposed to be in the config for which to get the value
+    # @return the value for the given key
     def fetch(key)
-      raise Error::InvalidCollection unless @config.key? key
+      raise Error::InvalidCollection, "Fetching key #{key} failed" unless @config.key?(key)
 
-      @config.dig key
+      @config.dig(key)
     end
 
-    #
-    #
+    # Read the source file for the data set 
+    # and parse it according to the file type 
+    # Raise an error if
+    #  * The file does not exist
+    #  * The file extension is invalid
+    #  * The file could not be parsed
     def ingest_source
+      puts("Ingesting source")
       file = "_data/#{@source}"
-      raise Error::InvalidSource, "Cannot find source file #{file}" unless File.exist? file
+      raise Error::InvalidSource, "Cannot find source file #{file}" unless File.exist?(file)
 
-      case File.extname file
+      case File.extname(file)
       when '.csv'
-        CSV.read(file, headers: true).map(&:to_hash)
+        return CSV.read(file, headers: true).map(&:to_hash)
       when '.json'
-        JSON.parse(File.read(file).encode('UTF-8'))
+        return JSON.parse(File.read(file).encode('UTF-8'))
       when /\.ya?ml/
-        YAML.load_file file
+        return YAML.load_file(file)
       else
         raise Error::InvalidSource, "Collection source #{file} must have a valid extension (.csv, .yml, or .json)"
       end
@@ -43,22 +52,32 @@ module Pagemaster
       raise Error::InvalidSource, "Cannot load #{file}. check for typos and rebuild."
     end
 
-    #
-    #
+    # Goes over @data and checks for duplicate IDs and whether the @id_key is present.
+    # Raises an error if the criteria are not met.
+    # @return nothing
     def validate_data
-      ids = @data.map { |d| d.dig @id_key }
-      raise Error::InvalidCollection, "One or more items in collection '#{@name}' is missing required id for the id_key '#{@id_key}'" unless ids.all?
+      puts("Validating")
 
-      duplicates = ids.detect { |i| ids.count(i) > 1 } || []
-      raise Error::InvalidCollection, "The collection '#{@name}' has the follwing duplicate ids for id_key #{@id_key}: \n#{duplicates}" unless duplicates.empty?
+      puts("Checking if ID keys are present")
+      ids = @data.map { |data_entry| data_entry.dig(@id_key) }
+      unless ids.all?
+        raise Error::InvalidCollection, "One or more items in collection '#{@name}' is missing required id for the id_key '#{@id_key}'"
+      end
+
+      puts("Checking for duplicate ID keys")
+      duplicates = ids.detect { |id| ids.count(id) > 1 } || []
+      unless duplicates.empty?
+        raise Error::InvalidCollection, "The collection '#{@name}' has the following duplicate ids for id_key #{@id_key}: \n#{duplicates}"
+      end
+      puts(Rainbow("Validation complete").green)
     end
 
-    #
-    #
-    def overwrite_pages
+    # Removes the output directory if it exists
+    # Does nothing otherwise.
+    def remove_output_dir
       return unless @dir
 
-      FileUtils.rm_rf @dir
+      FileUtils.rm_rf(@dir)
       puts Rainbow("Overwriting #{@dir} directory with --force.").cyan
     end
 
@@ -68,20 +87,29 @@ module Pagemaster
       @opts   = opts
       @dir    = File.join [source_dir, collections_dir, "_#{@name}"].compact
 
-      overwrite_pages if @opts.fetch :force, false
-      FileUtils.mkdir_p @dir
+      remove_output_dir if @opts.fetch(:force, false)
+      FileUtils.mkdir_p(@dir)
       @data = ingest_source
       validate_data
 
-      @data.map do |d|
-        path = "#{@dir}/#{slug d[@id_key]}.md"
-        d['layout'] = @config['layout'] if @config.key? 'layout'
-        if File.exist? path
-          puts Rainbow("#{path} already exits. Skipping.").cyan
+      @data.map do |data_entry|
+        puts("Processing #{data_entry}")
+        path = "#{@dir}/#{slug(data_entry[@id_key])}.md"
+        title = data_entry.dig(@title_key)
+        new_entry = {}
+        puts("\tlayout")
+        new_entry['layout'] = @config['layout']       if @config.key?('layout')
+        puts("\ttitle: #{title}")
+        new_entry['title']  = title
+        puts("\tdata")
+        new_entry['data']   = data_entry
+
+        if File.exist?(path)
+          puts(Rainbow("#{path} already exits. Skipping.").cyan)
         else
-          File.open(path, 'w') { |f| f.write("#{d.to_yaml}---") }
+          File.open(path, 'w') { |file| file.write("#{new_entry.to_yaml}---") }
         end
-        path
+        puts(Rainbow("Written #{path}").cyan)
       end
     end
 

--- a/lib/pagemaster/collection.rb
+++ b/lib/pagemaster/collection.rb
@@ -112,7 +112,7 @@ module Pagemaster
       processed_paths = []
       @data.map do |data_entry|
         path = process_data_entry(data_entry)
-        processed_paths.append(path)
+        processed_paths << path
       end
       processed_paths
     end

--- a/lib/pagemaster/command.rb
+++ b/lib/pagemaster/command.rb
@@ -11,7 +11,7 @@ module Pagemaster
         c.option :force, '--force', 'Erases pre-existing collection before regenerating.'
         c.action do |args, options|
           site = Pagemaster::Site.new(args, options)
-          puts("Generating pages")
+          puts('Generating pages')
           site.generate_pages
         end
       end

--- a/lib/pagemaster/command.rb
+++ b/lib/pagemaster/command.rb
@@ -10,7 +10,8 @@ module Pagemaster
         c.description 'Generate md pages from collection data.'
         c.option :force, '--force', 'Erases pre-existing collection before regenerating.'
         c.action do |args, options|
-          site = Pagemaster::Site.new args, options
+          site = Pagemaster::Site.new(args, options)
+          puts("Generating pages")
           site.generate_pages
         end
       end

--- a/lib/pagemaster/site.rb
+++ b/lib/pagemaster/site.rb
@@ -20,22 +20,20 @@ module Pagemaster
         raise Error::MissingArgs, "You must specify one or more collections after 'jekyll pagemaster'"
       end
 
-      if @collections.empty?
-        raise Error::InvalidCollection, "Cannot find collection(s) #{@args} in config"
-      end
+      raise Error::InvalidCollection, "Cannot find collection(s) #{@args} in config" if @collections.empty?
     end
 
     #
     #
     def config_from_file
-      puts("Reading configuration")
-      return YAML.load_file("#{`pwd`.strip()}/_config.yml")
+      puts('Reading configuration')
+      YAML.load_file("#{`pwd`.strip}/_config.yml")
     end
 
     #
     #
     def parse_collections
-      puts("Parsing collection")
+      puts('Parsing collection')
       collections_config = @config.dig('collections')
 
       if collections_config.nil?
@@ -58,8 +56,8 @@ module Pagemaster
       paths = @collections.map do |collection_item|
         collection_item.generate_pages(@opts, @collections_dir, @source_dir)
       end.flatten
-      puts Rainbow("Done ✔").green
-      return paths
+      puts Rainbow('Done ✔').green
+      paths
     end
   end
 end

--- a/pagemaster.gemspec
+++ b/pagemaster.gemspec
@@ -7,14 +7,18 @@ Gem::Specification.new do |spec|
   spec.summary       = 'jekyll pagemaster plugin'
   spec.description   = 'jekyll plugin for generating md pages from csv/json/yml'
   spec.authors       = ['Marii Nyrop']
-  spec.files         = ['lib/pagemaster.rb']
+  spec.files         = ['lib/pagemaster.rb',
+                        'lib/pagemaster/collection.rb',
+                        'lib/pagemaster/command.rb',
+                        'lib/pagemaster/error.rb',
+                        'lib/pagemaster/site.rb']
   spec.require_path  = 'lib'
   spec.homepage      = 'https://github.com/mnyrop/pagemaster'
   spec.license       = 'MIT'
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_runtime_dependency 'jekyll', '~> 3.8'
+  spec.add_runtime_dependency 'jekyll', '~> 4.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'safe_yaml', '~> 1.0'
 

--- a/spec/pagemaster/collection.rb
+++ b/spec/pagemaster/collection.rb
@@ -48,15 +48,15 @@ describe Pagemaster::Collection do
     end
   end
 
-  describe '.overwrite_pages' do
+  describe '.remove_output_dir' do
     context 'if page directory does not exists' do
       it 'does nothing' do
-        expect { csv_collection.overwrite_pages }.not_to raise_error
+        expect { csv_collection.remove_output_dir }.not_to raise_error
       end
     end
 
     it 'removes the page directory' do
-      csv_collection.overwrite_pages
+      csv_collection.remove_output_dir
     end
   end
 end

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -21,3 +21,5 @@ collections:
     id_key:     pid
     layout:     test
     title_key:  gambrel
+    frontmatter_extra:
+      foo: bar

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -20,6 +20,7 @@ collections:
     source:     valid.yml
     id_key:     pid
     layout:     test
-    title_key:  gambrel
-    frontmatter_extra:
+    do_copy:
       foo: bar
+    do_resolve:
+      title: gambrel

--- a/spec/sample_site/_config.yml
+++ b/spec/sample_site/_config.yml
@@ -4,17 +4,20 @@ baseurl: ''
 
 collections:
   csv_collection:
-    output: true
-    source: valid.csv
-    id_key: pid
-    layout: test
+    output:     true
+    source:     valid.csv
+    id_key:     pid
+    layout:     test
+    title_key:  gambrel
   json_collection:
-    output: true
-    source: valid.json
-    id_key: pid
-    layout: test
+    output:     true
+    source:     valid.json
+    id_key:     pid
+    layout:     test
+    title_key:  gambrel
   yaml_collection:
-    output: true
-    source: valid.yml
-    id_key: pid
-    layout: test
+    output:     true
+    source:     valid.yml
+    id_key:     pid
+    layout:     test
+    title_key:  gambrel


### PR DESCRIPTION
Hi,
So, I tinkered with the _pagemaster_ to make it work for a current project and thought that I might upstream the changes so you can take them over if you like them.

## Main Changes:
In addition to a _id_key_ now also a _title_key_ is required in the `_config.yml`
The _title_key_ gives the name of the field within a collection entry which will
be set as the pages' title via the Markdown frontmatter _title_.
The collection entry itself will no longer be pasted 1:1 into the Markdown
frontmatter but rather be a subobject of the _data_ field.

### Example
_config.yml
``` yml
collections:
  members:
    output:     true
    source:     team.yml
    id_key:     id
    title_key:  name
    layout:     member
```
together with  _data/team.yml
``` yml
- id:           yml-test
  name:         Einstein, Albert
  title:        Prof. Dr.
```
yields _members/yml-test.md
```markdown
---
layout: member
title: Einstein, Albert
data:
  id: yml-test
  name: Einstein, Albert
  title: Prof. Dr.
---
```

## Minor Changes:
	* Refactored some modifiers into statements for better reading flow.
	* Added parentheses for easier discerning of method application
	* Renamed iterators to be more meaningful
	* Renamed "overwrite_pages" to "remove_output_dir" to better match
	  its actual function
	* Added documentation comments